### PR TITLE
🛡️ Sentinel: Improve distributed sync responsiveness and stability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-11 - [Distributed Lock Flakiness and Context Responsiveness]
+**Vulnerability:** Distributed locks implemented with `SetNX` followed by `Get` can be flaky if the key expires or is deleted between the two operations. This causes unexpected errors and potential lock acquisition failures. Also, non-context-aware sleep in spin loops can lead to resource leaks (DoS) when contexts are cancelled.
+**Learning:** Always check for `redis.Nil` errors when performing follow-up checks after a failed `SetNX`. Use context-aware sleep functions like `gutils.SleepWithContext` to ensure goroutines exit promptly upon cancellation.
+**Prevention:** Use established patterns for distributed locks that handle transient "nil" results gracefully by retrying. Always perform nil checks on context cancel functions to prevent panics in `Unlock` methods.

--- a/mutex.go
+++ b/mutex.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	gutils "github.com/Laisky/go-utils/v5"
 	glog "github.com/Laisky/go-utils/v5/log"
 	"github.com/Laisky/zap"
 	"github.com/google/uuid"
@@ -37,7 +38,7 @@ func newMutexOption() *mutexOption {
 	}
 }
 
-// mutexType distributed mutex
+// Mutex distributed mutex
 //
 // Redis keys:
 //
@@ -189,6 +190,10 @@ func (m *mutex) Lock(ctx context.Context) (locked bool, lockCtx context.Context,
 			return false, nil, errors.WithStack(err)
 		} else if !locked {
 			if val, err := m.rdb.Get(ctx, m.name).Result(); err != nil {
+				if IsNil(err) { // key expired or deleted between SetNX and Get
+					continue
+				}
+
 				return false, nil, errors.Wrapf(err, "get `%s`", m.name)
 			} else if val != m.clientID {
 				// if val == m.clientID, means this client already acquired lock
@@ -196,7 +201,7 @@ func (m *mutex) Lock(ctx context.Context) (locked bool, lockCtx context.Context,
 					return false, nil, nil
 				}
 
-				time.Sleep(m.spinInterval)
+				gutils.SleepWithContext(ctx, m.spinInterval)
 				continue
 			}
 		}
@@ -233,8 +238,11 @@ func (m *mutex) Unlock(ctx context.Context) error {
 			return errors.WithStack(err)
 		}
 
-		m.cancel()
-		m.cancel = nil
+		if m.cancel != nil {
+			m.cancel()
+			m.cancel = nil
+		}
+
 		return
 	}, m.name))
 }

--- a/semaphore.go
+++ b/semaphore.go
@@ -211,7 +211,7 @@ func (s *semaphore) Lock(ctx context.Context) (locked bool, lockCtx context.Cont
 				return false, nil, nil
 			}
 
-			time.Sleep(s.spinInterval)
+			gutils.SleepWithContext(ctx, s.spinInterval)
 			continue
 		}
 
@@ -236,7 +236,11 @@ func (s *semaphore) Unlock(ctx context.Context) (err error) {
 		return errors.WithStack(err)
 	}
 
-	s.cancel()
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+
 	return
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Improve distributed sync responsiveness and stability

- Replace \`time.Sleep\` with context-aware \`gutils.SleepWithContext\` in \`Mutex\` and \`Semaphore\` spin-locks to prevent resource exhaustion on cancellation.
- Add nil checks for context cancel functions in \`Unlock\` methods to prevent panics.
- Handle \`redis: nil\` in \`Mutex.Lock\` to fix flakiness when keys expire between \`SetNX\` and \`Get\`.
- Add security journal at \`.jules/sentinel.md\`.

---
*PR created automatically by Jules for task [7098880436696081100](https://jules.google.com/task/7098880436696081100) started by @Laisky*